### PR TITLE
Add utilities to Priority Queue

### DIFF
--- a/src/queues/priority_queue/index.ts
+++ b/src/queues/priority_queue/index.ts
@@ -42,12 +42,72 @@ export function PriorityQueue<T>(heapDegree: number = 2) {
       index = smallest;
     }
   };
+
+  /**
+   * Given an index and the updated priority, adjusts the queue to maintain its heap property, in-place.
+   * @param idx The existing index of the targeted element.
+   * @param newPriority The new priority of the element located at `idx`.
+   * @returns The new index of the given element.
+   * If an improper index is input to this function (ex: more than the length or less than -1), returns -1.
+   */
+  const updatePriority = (idx: number, newPriority: number) => {
+    if (idx >= _items.length || idx < 0) {
+      return -1;
+    }
+    // heapify up
+    let newIdx = idx;
+    _items[newIdx][1] = newPriority;
+    while (newIdx > 0) {
+      let [, priority] = _items[newIdx];
+      let parentIdx = Math.floor((newIdx - 1) / heapDegree);
+      const [, parentPriority] = _items[parentIdx];
+      if (parentPriority > priority) {
+        [_items[parentIdx], _items[newIdx]] = [
+          _items[newIdx],
+          _items[parentIdx],
+        ];
+        newIdx = parentIdx;
+      } else {
+        break;
+      }
+    }
+    if (newIdx !== idx) {
+      return newIdx;
+    }
+    // heapify down if element wasn't heapified up (priority decreased)
+    while (true) {
+      let smallestIdx = newIdx;
+      for (let k = 1; k <= heapDegree; k++) {
+        const curIdx = childIdx(newIdx, k);
+        if (curIdx >= _items.length) {
+          break;
+        }
+        const [, smallestPriority] = _items[smallestIdx];
+        const [, childPriority] = _items[curIdx];
+        if (smallestPriority > childPriority) {
+          smallestIdx = curIdx;
+        }
+      }
+      if (smallestIdx === newIdx) {
+        break;
+      }
+
+      [_items[smallestIdx], _items[newIdx]] = [
+        _items[newIdx],
+        _items[smallestIdx],
+      ];
+      newIdx = smallestIdx;
+    }
+    return newIdx;
+  };
+
   const queue = {
     push: (itemWithPriority: [T, number]) => {
       _items.push(itemWithPriority);
       heapifyUp(_items.length - 1);
       return _items.length;
     },
+    degree: heapDegree,
     min: () => {
       return _items[0];
     },
@@ -67,8 +127,10 @@ export function PriorityQueue<T>(heapDegree: number = 2) {
       }
       return minPrEl;
     },
-    length: _items.length,
+    updatePriority,
+    length: () => _items.length,
     queue: _items,
   };
+
   return queue;
 }

--- a/src/queues/priority_queue/index.ts
+++ b/src/queues/priority_queue/index.ts
@@ -127,9 +127,16 @@ export function PriorityQueue<T>(heapDegree: number = 2) {
       }
       return minPrEl;
     },
+    findIndex: _items.findIndex,
+    find: _items.find,
     updatePriority,
     length: () => _items.length,
     queue: _items,
+    [Symbol.iterator]: function* () {
+      for (let el of _items) {
+        yield el;
+      }
+    },
   };
 
   return queue;

--- a/src/queues/priority_queue/index.ts
+++ b/src/queues/priority_queue/index.ts
@@ -101,6 +101,52 @@ export function PriorityQueue<T>(heapDegree: number = 2) {
     return newIdx;
   };
 
+  const findByPriorityHelper = (rootIdx: number, priority: number) => {
+    if (!_items[rootIdx]) {
+      return -1;
+    }
+    const [, rootPriority] = _items[rootIdx];
+    if (rootPriority === priority) {
+      return rootIdx;
+    }
+    let idx = -1;
+    for (let k = 1; k <= heapDegree; k++) {
+      idx = findByPriorityHelper(childIdx(rootIdx, k), priority);
+      if (idx != -1) {
+        break;
+      }
+    }
+    return idx;
+  };
+
+  /**
+   * Finds an element in the queue with the given priority.
+   * Priority queue optimization is only available for the preference of `any`,
+   * i.e. when the position of the returned value does not matter in case of multiple matches.
+   * @param priority The target priority.
+   * @param preference Preference of element position in case of multiple matches.
+   * @returns The first element in the queue with the given priority.
+   */
+  const findByPriority = (
+    priority: number,
+    preference: "any" | "first" | "last" = "first"
+  ) => {
+    if (!queue.length()) {
+      return -1;
+    }
+    if (preference === "first") {
+      return _items.findIndex((element) => element[1] === priority);
+    }
+    if (preference === "last") {
+      for (let i = _items.length - 1; i >= 0; i--) {
+        if (_items[i][1] === priority) {
+          return i;
+        }
+      }
+    }
+    return findByPriorityHelper(0, priority);
+  };
+
   const queue = {
     push: (itemWithPriority: [T, number]) => {
       _items.push(itemWithPriority);
@@ -129,6 +175,7 @@ export function PriorityQueue<T>(heapDegree: number = 2) {
     },
     findIndex: _items.findIndex,
     find: _items.find,
+    findByPriority,
     updatePriority,
     length: () => _items.length,
     queue: _items,

--- a/test/queues/cases/priority_queue.ts
+++ b/test/queues/cases/priority_queue.ts
@@ -5,6 +5,13 @@ type InsertionCase = {
   expectedQueue: [number, number][];
 };
 
+type UpdateCase = {
+  queueOriginal: [number, number][];
+  updateIdx: number;
+  updatedPriority: number;
+  queueUpdated: [number, number][];
+};
+
 export const validBinaryPqInsertions: InsertionCase[] = [
   {
     insert: [5, 5],
@@ -202,8 +209,8 @@ export const deletionResults3Ary = [
   ],
   [
     [5, 5],
-    [10, 10],
     [8, 8],
+    [10, 10],
   ],
   [
     [8, 8],
@@ -211,4 +218,244 @@ export const deletionResults3Ary = [
   ],
   [[10, 10]],
   [],
+];
+
+export const updateBinaryPriorityTests: UpdateCase[] = [
+  {
+    queueOriginal: [
+      [2, 1],
+      [1, 2],
+      [3, 4],
+      [4, 5],
+      [5, 3],
+      [6, 6],
+      [7, 7],
+      [8, 10],
+    ],
+    updateIdx: 3,
+    updatedPriority: 0,
+    queueUpdated: [
+      [4, 0],
+      [2, 1],
+      [3, 4],
+      [1, 2],
+      [5, 3],
+      [6, 6],
+      [7, 7],
+      [8, 10],
+    ],
+  },
+  {
+    queueOriginal: [
+      [41, 1],
+      [43, 2],
+      [39, 3],
+      [40, 4],
+      [42, 5],
+      [44, 6],
+      [45, 4],
+    ],
+    updateIdx: 5,
+    updatedPriority: 0,
+    queueUpdated: [
+      [44, 0],
+      [43, 2],
+      [41, 1],
+      [40, 4],
+      [42, 5],
+      [39, 3],
+      [45, 4],
+    ],
+  },
+  {
+    queueOriginal: [
+      [10, 1],
+      [12, 4],
+      [13, 3],
+      [11, 6],
+      [9, 5],
+      [14, 7],
+      [15, 5],
+    ],
+    updateIdx: 6,
+    updatedPriority: 4,
+    queueUpdated: [
+      [10, 1],
+      [12, 4],
+      [13, 3],
+      [11, 6],
+      [9, 5],
+      [14, 7],
+      [15, 4],
+    ],
+  },
+  {
+    queueOriginal: [
+      [17, 1],
+      [16, 4],
+      [18, 5],
+      [19, 6],
+      [20, 7],
+      [21, 6],
+      [22, 7],
+    ],
+    updateIdx: 1,
+    updatedPriority: 8,
+    queueUpdated: [
+      [17, 1],
+      [19, 6],
+      [18, 5],
+      [16, 8],
+      [20, 7],
+      [21, 6],
+      [22, 7],
+    ],
+  },
+  {
+    queueOriginal: [
+      [25, 2],
+      [24, 3],
+      [23, 5],
+      [26, 4],
+      [27, 5],
+      [28, 6],
+      [29, 8],
+      [30, 5],
+    ],
+    updateIdx: 0,
+    updatedPriority: 8,
+    queueUpdated: [
+      [24, 3],
+      [26, 4],
+      [23, 5],
+      [30, 5],
+      [27, 5],
+      [28, 6],
+      [29, 8],
+      [25, 8],
+    ],
+  },
+  {
+    queueOriginal: [
+      [36, 1],
+      [31, 2],
+      [34, 3],
+      [33, 4],
+      [32, 6],
+      [35, 5],
+      [37, 4],
+      [38, 8],
+    ],
+    updateIdx: 7,
+    updatedPriority: 12,
+    queueUpdated: [
+      [36, 1],
+      [31, 2],
+      [34, 3],
+      [33, 4],
+      [32, 6],
+      [35, 5],
+      [37, 4],
+      [38, 12],
+    ],
+  },
+];
+
+export const updateTriaryPriorityTests: UpdateCase[] = [
+  {
+    queueOriginal: [
+      [36, 1],
+      [31, 2],
+      [34, 3],
+      [33, 4],
+      [32, 6],
+      [35, 5],
+      [37, 4],
+      [38, 8],
+    ],
+    updateIdx: 7,
+    updatedPriority: 0,
+    queueUpdated: [
+      [38, 0],
+      [31, 2],
+      [36, 1],
+      [33, 4],
+      [32, 6],
+      [35, 5],
+      [37, 4],
+      [34, 3],
+    ],
+  },
+  {
+    queueOriginal: [
+      [36, 1],
+      [31, 2],
+      [34, 3],
+      [33, 4],
+      [32, 6],
+      [35, 5],
+      [37, 4],
+      [38, 8],
+    ],
+    updateIdx: 0,
+    updatedPriority: 10,
+    queueUpdated: [
+      [31, 2],
+      [37, 4],
+      [34, 3],
+      [33, 4],
+      [32, 6],
+      [35, 5],
+      [36, 10],
+      [38, 8],
+    ],
+  },
+  {
+    queueOriginal: [
+      [148, 1],
+      [145, 2],
+      [143, 3],
+      [144, 4],
+      [146, 6],
+      [147, 5],
+      [149, 3],
+      [150, 4],
+    ],
+    updateIdx: 2,
+    updatedPriority: 10,
+    queueUpdated: [
+      [148, 1],
+      [145, 2],
+      [150, 4],
+      [144, 4],
+      [146, 6],
+      [147, 5],
+      [149, 3],
+      [143, 10],
+    ],
+  },
+  {
+    queueOriginal: [
+      [148, 1],
+      [145, 2],
+      [143, 3],
+      [144, 4],
+      [146, 6],
+      [147, 5],
+      [149, 3],
+      [150, 4],
+    ],
+    updateIdx: 2,
+    updatedPriority: 0,
+    queueUpdated: [
+      [143, 0],
+      [145, 2],
+      [148, 1],
+      [144, 4],
+      [146, 6],
+      [147, 5],
+      [149, 3],
+      [150, 4],
+    ],
+  },
 ];

--- a/test/queues/cases/priority_queue.ts
+++ b/test/queues/cases/priority_queue.ts
@@ -8,6 +8,7 @@ type InsertionCase = {
 type UpdateCase = {
   queueOriginal: [number, number][];
   updateIdx: number;
+  newIdx: number;
   updatedPriority: number;
   queueUpdated: [number, number][];
 };
@@ -233,6 +234,7 @@ export const updateBinaryPriorityTests: UpdateCase[] = [
       [8, 10],
     ],
     updateIdx: 3,
+    newIdx: 0,
     updatedPriority: 0,
     queueUpdated: [
       [4, 0],
@@ -256,6 +258,7 @@ export const updateBinaryPriorityTests: UpdateCase[] = [
       [45, 4],
     ],
     updateIdx: 5,
+    newIdx: 0,
     updatedPriority: 0,
     queueUpdated: [
       [44, 0],
@@ -278,6 +281,7 @@ export const updateBinaryPriorityTests: UpdateCase[] = [
       [15, 5],
     ],
     updateIdx: 6,
+    newIdx: 6,
     updatedPriority: 4,
     queueUpdated: [
       [10, 1],
@@ -300,6 +304,7 @@ export const updateBinaryPriorityTests: UpdateCase[] = [
       [22, 7],
     ],
     updateIdx: 1,
+    newIdx: 3,
     updatedPriority: 8,
     queueUpdated: [
       [17, 1],
@@ -323,6 +328,7 @@ export const updateBinaryPriorityTests: UpdateCase[] = [
       [30, 5],
     ],
     updateIdx: 0,
+    newIdx: 7,
     updatedPriority: 8,
     queueUpdated: [
       [24, 3],
@@ -347,6 +353,7 @@ export const updateBinaryPriorityTests: UpdateCase[] = [
       [38, 8],
     ],
     updateIdx: 7,
+    newIdx: 7,
     updatedPriority: 12,
     queueUpdated: [
       [36, 1],
@@ -374,6 +381,7 @@ export const updateTriaryPriorityTests: UpdateCase[] = [
       [38, 8],
     ],
     updateIdx: 7,
+    newIdx: 0,
     updatedPriority: 0,
     queueUpdated: [
       [38, 0],
@@ -398,6 +406,7 @@ export const updateTriaryPriorityTests: UpdateCase[] = [
       [38, 8],
     ],
     updateIdx: 0,
+    newIdx: 6,
     updatedPriority: 10,
     queueUpdated: [
       [31, 2],
@@ -422,6 +431,7 @@ export const updateTriaryPriorityTests: UpdateCase[] = [
       [150, 4],
     ],
     updateIdx: 2,
+    newIdx: 7,
     updatedPriority: 10,
     queueUpdated: [
       [148, 1],
@@ -446,6 +456,7 @@ export const updateTriaryPriorityTests: UpdateCase[] = [
       [150, 4],
     ],
     updateIdx: 2,
+    newIdx: 0,
     updatedPriority: 0,
     queueUpdated: [
       [143, 0],

--- a/test/queues/priority_queue.test.ts
+++ b/test/queues/priority_queue.test.ts
@@ -100,3 +100,77 @@ describe("Tests for updating the priority of an element -- Tri-ary Heap", () => 
     }
   );
 });
+
+describe("Tests for finding items by priority", () => {
+  it.each([2, 3])(
+    "Should return the correct index for each of the items searched by priority -- any order",
+    (degree) => {
+      const queue: [number, number][] = [
+        [148, 1],
+        [145, 2],
+        [143, 3],
+        [144, 4],
+        [146, 6],
+        [147, 5],
+        [149, 4],
+        [150, 5],
+      ];
+      const pq = PriorityQueueFactory<number>(degree);
+      queue.forEach((el) => pq.push(el));
+      expect(pq.findByPriority(1, "any")).toBe(0);
+      expect(pq.findByPriority(2, "any")).toBe(1);
+      expect(pq.findByPriority(3, "any")).toBe(2);
+      expect([3, 6]).toContain(pq.findByPriority(4, "any"));
+      expect([5, 7]).toContain(pq.findByPriority(5, "any"));
+      expect(pq.findByPriority(6, "any")).toBe(4);
+    }
+  );
+
+  it.each([2, 3])(
+    "Should return the correct index for each of the items searched by priority -- first element",
+    (degree) => {
+      const queue: [number, number][] = [
+        [148, 1],
+        [145, 2],
+        [143, 3],
+        [144, 4],
+        [146, 6],
+        [147, 5],
+        [149, 4],
+        [150, 5],
+      ];
+      const pq = PriorityQueueFactory<number>(degree);
+      queue.forEach((el) => pq.push(el));
+      expect(pq.findByPriority(1, "first")).toBe(0);
+      expect(pq.findByPriority(2, "first")).toBe(1);
+      expect(pq.findByPriority(3, "first")).toBe(2);
+      expect(pq.findByPriority(4, "first")).toBe(3);
+      expect(pq.findByPriority(5, "first")).toBe(5);
+      expect(pq.findByPriority(6, "first")).toBe(4);
+    }
+  );
+
+  it.each([2, 3])(
+    "Should return the correct index for each of the items searched by priority -- last element",
+    (degree) => {
+      const queue: [number, number][] = [
+        [148, 1],
+        [145, 2],
+        [143, 3],
+        [144, 4],
+        [146, 6],
+        [147, 5],
+        [149, 4],
+        [150, 5],
+      ];
+      const pq = PriorityQueueFactory<number>(degree);
+      queue.forEach((el) => pq.push(el));
+      expect(pq.findByPriority(1, "last")).toBe(0);
+      expect(pq.findByPriority(2, "last")).toBe(1);
+      expect(pq.findByPriority(3, "last")).toBe(2);
+      expect(pq.findByPriority(4, "last")).toBe(6);
+      expect(pq.findByPriority(5, "last")).toBe(7);
+      expect(pq.findByPriority(6, "last")).toBe(4);
+    }
+  );
+});

--- a/test/queues/priority_queue.test.ts
+++ b/test/queues/priority_queue.test.ts
@@ -75,26 +75,24 @@ describe("Tests for pushing and deleting items into the queue -- Tri-ary Heap", 
   });
 });
 
-describe("Tests for updating the priority of an element -- Binary Heap", () => {
+describe("Tests for updating the priority of an element", () => {
   it.each(updateBinaryPriorityTests)(
-    "Should update the queue maintaining the heap property",
-    ({ queueOriginal, updateIdx, updatedPriority, queueUpdated }) => {
+    "Should update the queue maintaining the heap property -- Binary heap",
+    ({ queueOriginal, updateIdx, updatedPriority, queueUpdated, newIdx }) => {
       const pq = PriorityQueueFactory<number>(2);
       queueOriginal.forEach((el) => pq.push(el));
-      pq.updatePriority(updateIdx, updatedPriority);
+      expect(pq.updatePriority(updateIdx, updatedPriority)).toBe(newIdx);
       expect(verifyHeapProperty(pq)).toBeTruthy();
       expect(pq.queue).toEqual(queueUpdated);
     }
   );
-});
 
-describe("Tests for updating the priority of an element -- Tri-ary Heap", () => {
   it.each(updateTriaryPriorityTests)(
-    "Should update the queue maintaining the heap property",
-    ({ queueOriginal, updateIdx, updatedPriority, queueUpdated }) => {
+    "Should update the queue maintaining the heap property -- Tri-ary heap",
+    ({ queueOriginal, updateIdx, updatedPriority, queueUpdated, newIdx }) => {
       const pq = PriorityQueueFactory<number>(3);
       queueOriginal.forEach((el) => pq.push(el));
-      pq.updatePriority(updateIdx, updatedPriority);
+      expect(pq.updatePriority(updateIdx, updatedPriority)).toBe(newIdx);
       expect(verifyHeapProperty(pq)).toBeTruthy();
       expect(pq.queue).toEqual(queueUpdated);
     }

--- a/test/queues/priority_queue.test.ts
+++ b/test/queues/priority_queue.test.ts
@@ -1,13 +1,32 @@
 import {
   deletionResults3Ary,
   deletionResultsBinary,
+  updateBinaryPriorityTests,
+  updateTriaryPriorityTests,
   valid3aryPqInsertions,
   validBinaryPqInsertions,
 } from "./cases/priority_queue";
-import { PriorityQueue } from "../../src/queues";
+import { PriorityQueue, PriorityQueueFactory } from "../../src/queues";
 
-describe("Tests for pushing items into the queue -- Binary Heap", () => {
-  let queue = PriorityQueue<number>(2);
+const verifyHeapProperty = (queue: PriorityQueue<any>) => {
+  const { degree } = queue;
+  for (let i = 0; i < queue.length(); i++) {
+    const [, priority] = queue.queue[i];
+    for (let j = degree * i + 1; j <= degree * i + degree; j++) {
+      if (j >= queue.length()) {
+        break;
+      }
+      const [, childPriority] = queue.queue[j];
+      if (priority > childPriority) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+describe("Tests for pushing and deleting items into the queue -- Binary Heap", () => {
+  let queue = PriorityQueueFactory<number>(2);
   it.each(validBinaryPqInsertions)(
     "Should return the number of elements in the queue on insertion",
     (insertion) => {
@@ -22,16 +41,16 @@ describe("Tests for pushing items into the queue -- Binary Heap", () => {
 
   it("Should maintain the heap property while deleting the minimum element", () => {
     let i = 0;
-    while (queue.length) {
+    while (queue.length()) {
       queue.shift();
-      expect(queue).toEqual(deletionResultsBinary[i]);
+      expect(queue.queue).toEqual(deletionResultsBinary[i]);
       i++;
     }
   });
 });
 
-describe("Tests for pushing items into the queue -- Tri-ary Heap", () => {
-  let queue = PriorityQueue<number>(3);
+describe("Tests for pushing and deleting items into the queue -- Tri-ary Heap", () => {
+  let queue = PriorityQueueFactory<number>(3);
   it.each(valid3aryPqInsertions)(
     "Should return the number of elements in the queue on insertion",
     (insertion) => {
@@ -41,15 +60,43 @@ describe("Tests for pushing items into the queue -- Tri-ary Heap", () => {
       expect(length).toBe(expectedLength);
       expect(queue.at(expectedPosition)).toEqual(insert);
       expect(queue.queue).toEqual(expectedQueue);
+      expect(verifyHeapProperty(queue)).toBeTruthy();
     }
   );
 
   it("Should maintain the heap property while deleting the minimum element", () => {
     let i = 0;
-    while (queue.length) {
+    while (queue.length()) {
       queue.shift();
-      expect(queue).toEqual(deletionResults3Ary[i]);
+      expect(queue.queue).toEqual(deletionResults3Ary[i]);
+      expect(verifyHeapProperty(queue)).toBeTruthy();
       i++;
     }
   });
+});
+
+describe("Tests for updating the priority of an element -- Binary Heap", () => {
+  it.each(updateBinaryPriorityTests)(
+    "Should update the queue maintaining the heap property",
+    ({ queueOriginal, updateIdx, updatedPriority, queueUpdated }) => {
+      const pq = PriorityQueueFactory<number>(2);
+      queueOriginal.forEach((el) => pq.push(el));
+      pq.updatePriority(updateIdx, updatedPriority);
+      expect(verifyHeapProperty(pq)).toBeTruthy();
+      expect(pq.queue).toEqual(queueUpdated);
+    }
+  );
+});
+
+describe("Tests for updating the priority of an element -- Tri-ary Heap", () => {
+  it.each(updateTriaryPriorityTests)(
+    "Should update the queue maintaining the heap property",
+    ({ queueOriginal, updateIdx, updatedPriority, queueUpdated }) => {
+      const pq = PriorityQueueFactory<number>(3);
+      queueOriginal.forEach((el) => pq.push(el));
+      pq.updatePriority(updateIdx, updatedPriority);
+      expect(verifyHeapProperty(pq)).toBeTruthy();
+      expect(pq.queue).toEqual(queueUpdated);
+    }
+  );
 });


### PR DESCRIPTION
Added the following functions to the `PriorityQueue` data structure:
- `findByPriority`: Finds an element by the given priority. Can specify a preference for first match, last match, or any match.
- `find`: JS Find on entries of the queue `[data: T, priority: number]`
- `findIndex`: JS FindIndex on entries of the queue `[data: T, priority: number]`
- `updatePriority`: Updates the priority of the element at the given index. Returns the new index of the element after the queue is adjusted to maintain the heap property.

Fixed the `length` property being static on the queue. It is now a **`function`**